### PR TITLE
more path and imports fixes

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -70,7 +70,7 @@ function check_structural_schema {
 }
 
 function wait_maroonedpods_available {
-  echo "Waiting $MAROONEDPODS_AVAILABLE_TIMEOUT seconds for MAROONEDPODS to become available"
+  echo "Waiting $MAROONEDPODS_AVAILABLE_TIMEOUT seconds for maroonedpods.io/${CR_NAME} to become available"
   if [ "$KUBEVIRT_PROVIDER" == "os-3.11.0-crio" ]; then
     echo "Openshift 3.11 provider"
     available=$(_kubectl get maroonedpods maroonedpods -o jsonpath={.status.conditions[0].status})
@@ -83,6 +83,7 @@ function wait_maroonedpods_available {
       fix_failed_sdn_pods
     done
   else
+    
     _kubectl wait maroonedpods.io/${CR_NAME} --for=condition=Available --timeout=${MAROONEDPODS_AVAILABLE_TIMEOUT}s
   fi
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -57,7 +57,7 @@ func (k maroonedpods) GeneratedMaroonedPodsClient() generatedclient.Interface {
 }
 
 func (k maroonedpods) MaroonedPods() MaroonedPodsInterface {
-	return k.generatedMaroonedPodsClient.MaroonedPodsV1alpha1().MaroonedPods()
+	return k.generatedMaroonedPodsClient.MaroonedpodsV1alpha1().MaroonedPodses()
 }
 
 func (k maroonedpods) DynamicClient() dynamic.Interface {

--- a/pkg/client/maroonedpodsCli.go
+++ b/pkg/client/maroonedpodsCli.go
@@ -64,7 +64,7 @@ type RestConfigHookFunc func(*rest.Config)
 var restConfigHooks []RestConfigHookFunc
 var restConfigHooksLock sync.Mutex
 
-var mpclient MaroondPodsClient
+var mpclient MaroonedPodsClient
 var once sync.Once
 
 // Init adds the default `kubeconfig` and `master` flags. It is not added by default to allow integration into

--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	k6tv1 "kubevirt.io/api/core/v1"
 	"maroonedpods.io/maroonedpods/pkg/client"
-	"maroonedpods.io/maroonedpods/pkg/util"
 	v1alpha13 "maroonedpods.io/maroonedpods/staging/src/maroonedpods.io/api/pkg/apis/core/v1alpha1"
 	"time"
 )

--- a/pkg/maroonedpods-controller/application.go
+++ b/pkg/maroonedpods-controller/application.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/clock"
 	maroonedpods_controller2 "maroonedpods.io/maroonedpods/pkg/maroonedpods-controller/maroonedpods-gate-controller"
 	"maroonedpods.io/maroonedpods/pkg/maroonedpods-controller/leaderelectionconfig"
 	"maroonedpods.io/maroonedpods/pkg/certificates/bootstrap"
@@ -52,7 +51,6 @@ type MaroonedPodsControllerApp struct {
 	LeaderElection               leaderelectionconfig.Configuration
 	maroonedpodsCli                       client.MaroonedPodsClient
 	maroonedPodsGateController            *maroonedpods_controller2.MaroonedPodsGateController
-	configController             *configuration_controller.MaroonedPodsConfigurationController
 	podInformer                  cache.SharedIndexInformer
 	maroonedpodsInformer                  cache.SharedIndexInformer
 	readyChan                    chan bool
@@ -123,7 +121,7 @@ func (mca *MaroonedPodsControllerApp) leaderProbe(_ *restful.Request, response *
 
 
 func (mca *MaroonedPodsControllerApp) initMaroonedPodsGateController(stop <-chan struct{}) {
-	mca.maroonedpodsGateController = maroonedpods_controller2.NewMaroonedPodsGateController(mca.maroonedpodsCli,
+	mca.maroonedPodsGateController = maroonedpods_controller2.NewMaroonedPodsGateController(mca.maroonedpodsCli,
 		mca.podInformer,
 		stop,
 		mca.enqueueAllGateControllerChan,
@@ -218,7 +216,7 @@ func (mca *MaroonedPodsControllerApp) onStartedLeading() func(ctx context.Contex
 		}
 
 		go func() {
-			mca.maroonedpodsGateController.Run(context.Background(), 3)
+			mca.maroonedPodsGateController.Run(context.Background(), 3)
 		}()
 		close(mca.readyChan)
 	}

--- a/pkg/maroonedpods-controller/maroonedpods-gate-controller/maroonedpods-gate-controller.go
+++ b/pkg/maroonedpods-controller/maroonedpods-gate-controller/maroonedpods-gate-controller.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -14,7 +12,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/clock"
 	_ "kubevirt.io/api/core/v1"
 	"maroonedpods.io/maroonedpods/pkg/client"
 	"maroonedpods.io/maroonedpods/pkg/log"
@@ -53,7 +50,6 @@ func NewMaroonedPodsGateController(maroonedpodsCli client.MaroonedPodsClient,
         queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "maroonedpods-queue"),
 
 		recorder:                     eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: util.ControllerPodName}),
-		maroonedpodsEvaluator:                 maroonedpods_evaluator.NewMaroonedPodsEvaluator(podInformer, calcRegistry, clock.RealClock{}),
 		stop:                         stop,
 		enqueueAllGateControllerChan: enqueueAllGateControllerChan,
 	}
@@ -136,7 +132,6 @@ func (ctrl *MaroonedPodsGateController) Run(ctx context.Context, threadiness int
 				return
 			case <-ctrl.enqueueAllGateControllerChan:
 				log.Log.Infof("MaroonedPodsGateController: Signal processed enqueued All")
-				ctrl.enqueueAll()
 			}
 		}
 	}()

--- a/pkg/maroonedpods-operator/cruft.go
+++ b/pkg/maroonedpods-operator/cruft.go
@@ -1,4 +1,4 @@
-package maroonpods_operator
+package maroonedpods_operator
 
 import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"

--- a/pkg/maroonedpods-operator/reconciler-hooks.go
+++ b/pkg/maroonedpods-operator/reconciler-hooks.go
@@ -1,4 +1,4 @@
-package maroonpods_operator
+package maroonedpods_operator
 
 import (
 	"context"

--- a/pkg/maroonedpods-operator/resources/namespaced/factory.go
+++ b/pkg/maroonedpods-operator/resources/namespaced/factory.go
@@ -14,7 +14,7 @@ type FactoryArgs struct {
 	OperatorVersion         string `required:"true" split_words:"true"`
 	ControllerImage         string `required:"true" split_words:"true"`
 	DeployClusterResources  string `required:"true" split_words:"true"`
-	MaroonedPodsServerImage string `required:"true" split_words:"true"`
+	MaroonedPodsServerImage string `required:"true" envconfig:"MAROONEDPODS_SERVER_IMAGE"`
 	Verbosity               string `required:"true"`
 	PullPolicy              string `required:"true" split_words:"true"`
 	ImagePullSecrets        []corev1.LocalObjectReference

--- a/pkg/maroonedpods-operator/resources/operator/factory.go
+++ b/pkg/maroonedpods-operator/resources/operator/factory.go
@@ -71,7 +71,7 @@ func CreateOperatorResourceGroup(group string, args *FactoryArgs) ([]client.Obje
 }
 
 // NewMaroonedPodsCrd - provides MaroonedPods CRD
-func NewNaroonedPodsCrd() *extv1.CustomResourceDefinition {
+func NewMaroonedPodsCrd() *extv1.CustomResourceDefinition {
 	return createMaroonedPodsListCRD()
 }
 


### PR DESCRIPTION
Additional fixes towards a successful cluster-sync ;)


Warning: kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2.
maroonedpods   pod/maroonedpods-controller-6f8d9b58c8-2t89b   1/1     Running   0          58m
maroonedpods   pod/maroonedpods-controller-6f8d9b58c8-ch476   1/1     Running   0          58m
maroonedpods   pod/maroonedpods-operator-8476d74b94-sx8h9     1/1     Running   0          58m
maroonedpods   pod/maroonedpods-server-5946b9bb69-ffw8n       1/1     Running   0          58m
maroonedpods   pod/maroonedpods-server-5946b9bb69-tdr8b       1/1     Running   0          58m
maroonedpods   service/maroonedpods-server           NodePort    10.104.129.105   <none>        443:31791/TCP            58m
maroonedpods   deployment.apps/maroonedpods-controller   2/2     2            2           58m
maroonedpods   deployment.apps/maroonedpods-operator     1/1     1            1           58m
maroonedpods   deployment.apps/maroonedpods-server       2/2     2            2           58m
maroonedpods   replicaset.apps/maroonedpods-controller-6f8d9b58c8   2         2         2       58m
maroonedpods   replicaset.apps/maroonedpods-operator-8476d74b94     1         1         1       58m
maroonedpods   replicaset.apps/maroonedpods-server-5946b9bb69       2         2         2       58m
