### PR TITLE
Add e2e functional tests with Ginkgo/Gomega

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -74,6 +74,7 @@ const (
 	OperatorServiceAccountName     = "maroonedpods-operator"
 	MaroonedPodsGate               = "MaroonedPodsGate"
 	MaroonedPodsFinalizer          = "maroonedpods.io/vmi-cleanup"
+	MaroonedPodLabel               = "maroonedpods.io/maroon"
 	ControllerResourceName         = ControllerPodName
 	SecretResourceName             = "maroonedpods-server-cert"
 	MaroonedPodsServerResourceName = "maroonedpods-server"

--- a/tests/builders/pod.go
+++ b/tests/builders/pod.go
@@ -1,0 +1,102 @@
+package builders
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"maroonedpods.io/maroonedpods/pkg/util"
+)
+
+// PodBuilder helps build test pods
+type PodBuilder struct {
+	pod *v1.Pod
+}
+
+// NewPod creates a new PodBuilder
+func NewPod(name, namespace string) *PodBuilder {
+	return &PodBuilder{
+		pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    make(map[string]string),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{},
+			},
+		},
+	}
+}
+
+// WithMaroonedLabel adds the maroonedpods.io/maroon label
+func (b *PodBuilder) WithMaroonedLabel() *PodBuilder {
+	b.pod.Labels[util.MaroonedPodLabel] = "true"
+	return b
+}
+
+// WithLabel adds a custom label
+func (b *PodBuilder) WithLabel(key, value string) *PodBuilder {
+	b.pod.Labels[key] = value
+	return b
+}
+
+// WithContainer adds a container to the pod
+func (b *PodBuilder) WithContainer(name, image string) *PodBuilder {
+	container := v1.Container{
+		Name:  name,
+		Image: image,
+	}
+	b.pod.Spec.Containers = append(b.pod.Spec.Containers, container)
+	return b
+}
+
+// WithContainerResources adds resource requests/limits to the last container
+func (b *PodBuilder) WithContainerResources(cpu, memory string) *PodBuilder {
+	if len(b.pod.Spec.Containers) == 0 {
+		return b
+	}
+
+	lastIdx := len(b.pod.Spec.Containers) - 1
+	b.pod.Spec.Containers[lastIdx].Resources = v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse(cpu),
+			v1.ResourceMemory: resource.MustParse(memory),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse(cpu),
+			v1.ResourceMemory: resource.MustParse(memory),
+		},
+	}
+	return b
+}
+
+// WithRestartPolicy sets the restart policy
+func (b *PodBuilder) WithRestartPolicy(policy v1.RestartPolicy) *PodBuilder {
+	b.pod.Spec.RestartPolicy = policy
+	return b
+}
+
+// Build returns the built pod
+func (b *PodBuilder) Build() *v1.Pod {
+	return b.pod
+}
+
+// NewMaroonedPod creates a simple marooned pod with nginx
+func NewMaroonedPod(name, namespace string) *v1.Pod {
+	return NewPod(name, namespace).
+		WithMaroonedLabel().
+		WithContainer("nginx", "nginx:latest").
+		WithRestartPolicy(v1.RestartPolicyAlways).
+		Build()
+}
+
+// NewMaroonedPodWithResources creates a marooned pod with specific resource requests
+func NewMaroonedPodWithResources(name, namespace, cpu, memory string) *v1.Pod {
+	return NewPod(name, namespace).
+		WithMaroonedLabel().
+		WithContainer("nginx", "nginx:latest").
+		WithContainerResources(cpu, memory).
+		WithRestartPolicy(v1.RestartPolicyAlways).
+		Build()
+}

--- a/tests/e2e_cleanup_test.go
+++ b/tests/e2e_cleanup_test.go
@@ -1,0 +1,126 @@
+package tests
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	"maroonedpods.io/maroonedpods/tests/builders"
+	"maroonedpods.io/maroonedpods/tests/framework"
+	testutils "maroonedpods.io/maroonedpods/tests/utils"
+)
+
+var _ = Describe("[e2e] Pod and VMI Cleanup", func() {
+	var (
+		f  *framework.Framework
+		ns string
+	)
+
+	BeforeEach(func() {
+		f = framework.DefaultFramework
+		nsName := testutils.GenerateNamespaceName("cleanup")
+		createdNs, err := f.CreateNamespace(nsName)
+		Expect(err).ToNot(HaveOccurred())
+		ns = createdNs.Name
+	})
+
+	AfterEach(func() {
+		if ns != "" {
+			err := f.DeleteNamespace(ns)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	It("should delete VMI when marooned pod is deleted", func() {
+		podName := "test-cleanup"
+
+		By("Creating a marooned pod")
+		pod := builders.NewMaroonedPod(podName, ns)
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for VMI to be created and running")
+		vmi, err := f.WaitForVMI(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi).ToNot(BeNil())
+
+		err = f.WaitForVMIPhase(ns, podName, virtv1.Running, testutils.LongTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deleting the pod")
+		err = f.DeletePod(podName)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the VMI is deleted")
+		err = f.WaitForVMIDeleted(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the pod is deleted")
+		err = f.WaitForPodDeleted(podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should handle graceful deletion", func() {
+		podName := "test-graceful"
+
+		By("Creating a marooned pod")
+		pod := builders.NewMaroonedPod(podName, ns)
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for VMI to exist")
+		_, err = f.WaitForVMI(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deleting the pod with grace period")
+		gracePeriod := int64(30)
+		deleteOptions := v1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriod,
+		}
+		err = f.K8sClient.CoreV1().Pods(ns).Delete(context.Background(), podName, deleteOptions)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the pod enters terminating state")
+		Eventually(func() bool {
+			p, err := f.GetPod(podName)
+			if err != nil {
+				return true // Pod might already be deleted
+			}
+			return p.DeletionTimestamp != nil
+		}, testutils.ShortTimeout, 2*time.Second).Should(BeTrue())
+
+		By("Verifying the VMI is eventually deleted")
+		err = f.WaitForVMIDeleted(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should clean up VMI even if pod is forcefully deleted", func() {
+		podName := "test-force-delete"
+
+		By("Creating a marooned pod")
+		pod := builders.NewMaroonedPod(podName, ns)
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for VMI to be created")
+		_, err = f.WaitForVMI(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Force deleting the pod")
+		gracePeriod := int64(0)
+		deleteOptions := v1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriod,
+		}
+		err = f.K8sClient.CoreV1().Pods(ns).Delete(context.Background(), podName, deleteOptions)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the VMI is cleaned up")
+		err = f.WaitForVMIDeleted(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/tests/e2e_dynamic_sizing_test.go
+++ b/tests/e2e_dynamic_sizing_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	"maroonedpods.io/maroonedpods/tests/builders"
+	"maroonedpods.io/maroonedpods/tests/framework"
+	testutils "maroonedpods.io/maroonedpods/tests/utils"
+)
+
+var _ = Describe("[e2e] Dynamic VM Sizing", func() {
+	var (
+		f  *framework.Framework
+		ns string
+	)
+
+	BeforeEach(func() {
+		f = framework.DefaultFramework
+		nsName := testutils.GenerateNamespaceName("dynamic-sizing")
+		createdNs, err := f.CreateNamespace(nsName)
+		Expect(err).ToNot(HaveOccurred())
+		ns = createdNs.Name
+	})
+
+	AfterEach(func() {
+		if ns != "" {
+			err := f.DeleteNamespace(ns)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	It("should size VMI based on pod resource requests", func() {
+		podName := "test-sizing"
+		cpuRequest := "2"
+		memoryRequest := "4Gi"
+
+		By("Creating a marooned pod with specific resource requests")
+		pod := builders.NewMaroonedPodWithResources(podName, ns, cpuRequest, memoryRequest)
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for VMI to be created")
+		vmi, err := f.WaitForVMI(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying VMI has appropriate resources")
+		// The VMI should have resources >= pod requests (accounting for overhead)
+		// Base VM is typically 1 CPU / 1Gi, overhead is 500m CPU / 512Mi
+		// So for 2 CPU / 4Gi pod, VMI should have at least 3 CPUs (2 + 1 for overhead rounded up)
+		// and at least 4.5Gi memory (4Gi + 512Mi)
+
+		// Check CPU cores (should be >= 3)
+		totalCores := vmi.Spec.Domain.CPU.Cores * vmi.Spec.Domain.CPU.Sockets * vmi.Spec.Domain.CPU.Threads
+		Expect(totalCores).To(BeNumerically(">=", uint32(3)), "VMI should have at least 3 CPU cores")
+
+		// Check memory (should be >= 4608Mi which is 4.5Gi)
+		guestMemory := vmi.Spec.Domain.Resources.Requests.Memory()
+		minMemory := resource.MustParse("4608Mi") // 4.5Gi
+		Expect(guestMemory.Cmp(minMemory)).To(BeNumerically(">=", 0), "VMI memory should be at least 4.5Gi")
+	})
+
+	It("should use minimum base resources for small pods", func() {
+		podName := "test-small-pod"
+		cpuRequest := "100m"
+		memoryRequest := "128Mi"
+
+		By("Creating a marooned pod with minimal resource requests")
+		pod := builders.NewMaroonedPodWithResources(podName, ns, cpuRequest, memoryRequest)
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for VMI to be created")
+		vmi, err := f.WaitForVMI(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying VMI uses base minimum resources")
+		// Even though pod requests are tiny, VMI should have base resources
+		// Base is typically 1 CPU / 1Gi minimum
+		totalCores := vmi.Spec.Domain.CPU.Cores * vmi.Spec.Domain.CPU.Sockets * vmi.Spec.Domain.CPU.Threads
+		Expect(totalCores).To(BeNumerically(">=", uint32(1)), "VMI should have at least 1 CPU core")
+
+		guestMemory := vmi.Spec.Domain.Resources.Requests.Memory()
+		minMemory := resource.MustParse("1Gi")
+		Expect(guestMemory.Cmp(minMemory)).To(BeNumerically(">=", 0), "VMI memory should be at least 1Gi")
+	})
+
+	It("should handle pods without resource requests", func() {
+		podName := "test-no-resources"
+
+		By("Creating a marooned pod without resource requests")
+		pod := builders.NewMaroonedPod(podName, ns)
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for VMI to be created")
+		vmi, err := f.WaitForVMI(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying VMI uses default base resources")
+		totalCores := vmi.Spec.Domain.CPU.Cores * vmi.Spec.Domain.CPU.Sockets * vmi.Spec.Domain.CPU.Threads
+		Expect(totalCores).To(BeNumerically(">=", uint32(1)))
+
+		// Should still be able to reach running state
+		err = f.WaitForVMIPhase(ns, podName, virtv1.Running, testutils.LongTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/tests/e2e_pod_isolation_test.go
+++ b/tests/e2e_pod_isolation_test.go
@@ -1,0 +1,165 @@
+package tests
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	"maroonedpods.io/maroonedpods/pkg/util"
+	"maroonedpods.io/maroonedpods/tests/builders"
+	"maroonedpods.io/maroonedpods/tests/framework"
+	testutils "maroonedpods.io/maroonedpods/tests/utils"
+)
+
+var _ = Describe("[e2e] Pod Isolation", func() {
+	var (
+		f  *framework.Framework
+		ns string
+	)
+
+	BeforeEach(func() {
+		f = framework.DefaultFramework
+		nsName := testutils.GenerateNamespaceName("pod-isolation")
+		createdNs, err := f.CreateNamespace(nsName)
+		Expect(err).ToNot(HaveOccurred())
+		ns = createdNs.Name
+	})
+
+	AfterEach(func() {
+		if ns != "" {
+			err := f.DeleteNamespace(ns)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	It("should create a VMI when a marooned pod is created", func() {
+		podName := "test-nginx"
+
+		By("Creating a marooned pod")
+		pod := builders.NewMaroonedPod(podName, ns)
+		createdPod, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createdPod).ToNot(BeNil())
+
+		By("Verifying the pod has the marooned label")
+		Expect(createdPod.Labels[util.MaroonedPodLabel]).To(Equal("true"))
+
+		By("Verifying the pod gets a scheduling gate")
+		Eventually(func() bool {
+			p, err := f.GetPod(podName)
+			if err != nil {
+				return false
+			}
+			for _, gate := range p.Spec.SchedulingGates {
+				if gate.Name == util.MaroonedPodsGate {
+					return true
+				}
+			}
+			return false
+		}, testutils.ShortTimeout, 2*time.Second).Should(BeTrue())
+
+		By("Waiting for VMI to be created")
+		vmi, err := f.WaitForVMI(ns, podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi).ToNot(BeNil())
+		Expect(vmi.Name).To(Equal(podName))
+
+		By("Waiting for VMI to be running")
+		err = f.WaitForVMIPhase(ns, podName, virtv1.Running, testutils.LongTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the node joins the cluster")
+		err = f.WaitForNodeReady(podName, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the scheduling gate is removed")
+		Eventually(func() bool {
+			p, err := f.GetPod(podName)
+			if err != nil {
+				return false
+			}
+			return len(p.Spec.SchedulingGates) == 0
+		}, testutils.DefaultTimeout, 2*time.Second).Should(BeTrue())
+
+		By("Waiting for pod to be running")
+		err = f.WaitForPodPhase(podName, v1.PodRunning, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the pod is running on the dedicated node")
+		finalPod, err := f.GetPod(podName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(finalPod.Spec.NodeName).To(Equal(podName))
+		Expect(finalPod.Status.Phase).To(Equal(v1.PodRunning))
+	})
+
+	It("should handle multiple marooned pods in the same namespace", func() {
+		pod1Name := "test-nginx-1"
+		pod2Name := "test-nginx-2"
+
+		By("Creating first marooned pod")
+		pod1 := builders.NewMaroonedPod(pod1Name, ns)
+		_, err := f.CreatePod(pod1)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Creating second marooned pod")
+		pod2 := builders.NewMaroonedPod(pod2Name, ns)
+		_, err = f.CreatePod(pod2)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for both VMIs to be created")
+		vmi1, err := f.WaitForVMI(ns, pod1Name, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi1).ToNot(BeNil())
+
+		vmi2, err := f.WaitForVMI(ns, pod2Name, testutils.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi2).ToNot(BeNil())
+
+		By("Verifying both VMIs are distinct")
+		Expect(vmi1.Name).ToNot(Equal(vmi2.Name))
+	})
+
+	It("should not create a VMI for a pod without the marooned label", func() {
+		podName := "regular-nginx"
+
+		By("Creating a regular pod without marooned label")
+		pod := builders.NewPod(podName, ns).
+			WithContainer("nginx", "nginx:latest").
+			Build()
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying no VMI is created")
+		time.Sleep(10 * time.Second) // Give some time for VMI creation if it would happen
+		_, err = f.GetVMI(ns, podName)
+		Expect(err).To(HaveOccurred()) // Should not find the VMI
+	})
+
+	It("should add finalizer to marooned pod", func() {
+		podName := "test-finalizer"
+
+		By("Creating a marooned pod")
+		pod := builders.NewMaroonedPod(podName, ns)
+		_, err := f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the pod gets a finalizer")
+		Eventually(func() bool {
+			p, err := f.GetPod(podName)
+			if err != nil {
+				return false
+			}
+			for _, finalizer := range p.Finalizers {
+				if finalizer == util.MaroonedPodsFinalizer {
+					return true
+				}
+			}
+			return false
+		}, testutils.ShortTimeout, 2*time.Second).Should(BeTrue())
+	})
+})

--- a/tests/e2e_warm_pool_test.go
+++ b/tests/e2e_warm_pool_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	"maroonedpods.io/maroonedpods/pkg/util"
+	"maroonedpods.io/maroonedpods/tests/builders"
+	"maroonedpods.io/maroonedpods/tests/framework"
+	testutils "maroonedpods.io/maroonedpods/tests/utils"
+)
+
+var _ = Describe("[e2e] Warm Pool", func() {
+	var (
+		f  *framework.Framework
+		ns string
+	)
+
+	BeforeEach(func() {
+		f = framework.DefaultFramework
+		nsName := testutils.GenerateNamespaceName("warm-pool")
+		createdNs, err := f.CreateNamespace(nsName)
+		Expect(err).ToNot(HaveOccurred())
+		ns = createdNs.Name
+	})
+
+	AfterEach(func() {
+		if ns != "" {
+			err := f.DeleteNamespace(ns)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	It("should support claiming VMI from warm pool if available", func() {
+		podName := "test-pool-claim"
+
+		By("Checking if warm pool is enabled by looking for pool VMIs")
+		// This test is conditional on warm pool being configured
+		// If no pool VMIs exist, we skip this test
+		mpNs := "maroonedpods" // Default operator namespace
+		vmiList, err := f.ListVMIs(mpNs)
+		Expect(err).ToNot(HaveOccurred())
+
+		poolVMIs := 0
+		for _, vmi := range vmiList.Items {
+			if vmi.Labels != nil {
+				if state, ok := vmi.Labels[util.WarmPoolStateLabel]; ok {
+					if state == util.PoolStateAvailable {
+						poolVMIs++
+					}
+				}
+			}
+		}
+
+		if poolVMIs == 0 {
+			Skip("No available pool VMIs found, skipping warm pool test")
+		}
+
+		By("Creating a marooned pod")
+		pod := builders.NewMaroonedPod(podName, ns)
+		_, err = f.CreatePod(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for pod to potentially claim a pool VMI")
+		// If warm pool is working, the pod should schedule faster
+		time.Sleep(5 * time.Second)
+
+		By("Checking if a VMI exists for the pod")
+		// The VMI might be from the pool or newly created
+		_, err = f.GetVMI(ns, podName)
+		// We just verify a VMI exists, we don't require it to be from the pool
+		// as that depends on pool availability and timing
+	})
+
+	It("should track pool VMI states correctly", func() {
+		By("Listing all VMIs in maroonedpods namespace")
+		mpNs := "maroonedpods"
+		vmiList, err := f.ListVMIs(mpNs)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Checking pool VMI state labels")
+		for _, vmi := range vmiList.Items {
+			if vmi.Labels != nil {
+				if state, ok := vmi.Labels[util.WarmPoolStateLabel]; ok {
+					By("Found pool VMI: " + vmi.Name + " with state: " + state)
+					// State should be one of: creating, available, claimed
+					Expect(state).To(BeElementOf(
+						util.PoolStateCreating,
+						util.PoolStateAvailable,
+						util.PoolStateClaimed,
+					))
+
+					// If claimed, should have claimed-by label
+					if state == util.PoolStateClaimed {
+						_, hasClaimedBy := vmi.Labels[util.WarmPoolClaimedByLabel]
+						Expect(hasClaimedBy).To(BeTrue(), "Claimed VMI should have claimed-by label")
+					}
+				}
+			}
+		}
+	})
+
+	It("should have pool VMIs with correct naming", func() {
+		By("Listing all VMIs in maroonedpods namespace")
+		mpNs := "maroonedpods"
+		vmiList, err := f.ListVMIs(mpNs)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Checking pool VMI names")
+		foundPoolVMI := false
+		for _, vmi := range vmiList.Items {
+			if vmi.Labels != nil {
+				if _, ok := vmi.Labels[util.WarmPoolStateLabel]; ok {
+					foundPoolVMI = true
+					// Pool VMIs should have the pool name prefix
+					Expect(vmi.Name).To(HavePrefix(util.WarmPoolVMNamePrefix),
+						"Pool VMI should have correct name prefix")
+				}
+			}
+		}
+
+		if !foundPoolVMI {
+			Skip("No pool VMIs found in cluster")
+		}
+	})
+})

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -1,0 +1,53 @@
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+var (
+	KubeConfig               *string
+	KubeURL                  *string
+	KubectlPath              *string
+	MaroonedPodsNamespace    *string
+	DockerPrefix             *string
+	DockerTag                *string
+)
+
+func InitFlags() {
+	KubeConfig = flag.String("kubeconfig", "", "Kubeconfig file path (optional)")
+	KubeURL = flag.String("kubeurl", "", "Kubernetes API server URL (optional)")
+	KubectlPath = flag.String("kubectl-path-maroonedpods", "", "Path to kubectl binary")
+	MaroonedPodsNamespace = flag.String("maroonedpods-namespace", "maroonedpods", "MaroonedPods operator namespace")
+	DockerPrefix = flag.String("docker-prefix", "", "Docker image prefix")
+	DockerTag = flag.String("docker-tag", "", "Docker image tag")
+}
+
+func NormalizeFlags() {
+	// Initialize flags if not already initialized
+	if KubeConfig == nil {
+		InitFlags()
+	}
+
+	// Set defaults from environment if not provided
+	if *KubeConfig == "" {
+		if kc := os.Getenv("KUBECONFIG"); kc != "" {
+			*KubeConfig = kc
+		}
+	}
+
+	if *KubectlPath == "" {
+		*KubectlPath = "kubectl"
+	}
+}
+
+func PrintFlags() {
+	fmt.Printf("Test Configuration:\n")
+	fmt.Printf("  KubeConfig: %s\n", *KubeConfig)
+	fmt.Printf("  KubeURL: %s\n", *KubeURL)
+	fmt.Printf("  KubectlPath: %s\n", *KubectlPath)
+	fmt.Printf("  MaroonedPodsNamespace: %s\n", *MaroonedPodsNamespace)
+	fmt.Printf("  DockerPrefix: %s\n", *DockerPrefix)
+	fmt.Printf("  DockerTag: %s\n", *DockerTag)
+}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -1,0 +1,218 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	virtv1 "kubevirt.io/api/core/v1"
+	kubevirtclient "kubevirt.io/client-go/kubecli"
+
+	mpv1alpha1 "maroonedpods.io/maroonedpods/staging/src/maroonedpods.io/api/pkg/apis/core/v1alpha1"
+	"maroonedpods.io/maroonedpods/tests/flags"
+)
+
+// Framework provides access to Kubernetes and KubeVirt clients for tests
+type Framework struct {
+	K8sClient       kubernetes.Interface
+	KubevirtClient  kubevirtclient.KubevirtClient
+	RestConfig      *rest.Config
+	Namespace       *v1.Namespace
+	NamespaceName   string
+	mpNamespace     string
+}
+
+var (
+	// DefaultFramework is the global test framework instance
+	DefaultFramework *Framework
+)
+
+// InitFramework initializes the global test framework
+func InitFramework() {
+	var err error
+	DefaultFramework, err = NewFramework()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to initialize test framework: %v", err))
+	}
+	flags.PrintFlags()
+}
+
+// NewFramework creates a new test framework instance
+func NewFramework() (*Framework, error) {
+	f := &Framework{
+		mpNamespace: *flags.MaroonedPodsNamespace,
+	}
+
+	// Build Kubernetes config
+	var err error
+	if *flags.KubeConfig != "" {
+		f.RestConfig, err = clientcmd.BuildConfigFromFlags(*flags.KubeURL, *flags.KubeConfig)
+	} else {
+		f.RestConfig, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubeconfig: %v", err)
+	}
+
+	// Create Kubernetes client
+	f.K8sClient, err = kubernetes.NewForConfig(f.RestConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	// Create KubeVirt client
+	f.KubevirtClient, err = kubevirtclient.GetKubevirtClientFromRESTConfig(f.RestConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubevirt client: %v", err)
+	}
+
+	return f, nil
+}
+
+// CreateNamespace creates a new test namespace
+func (f *Framework) CreateNamespace(name string) (*v1.Namespace, error) {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"test": "maroonedpods-e2e",
+			},
+		},
+	}
+
+	createdNs, err := f.K8sClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	f.Namespace = createdNs
+	f.NamespaceName = createdNs.Name
+	return createdNs, nil
+}
+
+// DeleteNamespace deletes a test namespace
+func (f *Framework) DeleteNamespace(name string) error {
+	return f.K8sClient.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+// CreatePod creates a pod in the test namespace
+func (f *Framework) CreatePod(pod *v1.Pod) (*v1.Pod, error) {
+	return f.K8sClient.CoreV1().Pods(f.NamespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
+}
+
+// GetPod gets a pod from the test namespace
+func (f *Framework) GetPod(name string) (*v1.Pod, error) {
+	return f.K8sClient.CoreV1().Pods(f.NamespaceName).Get(context.Background(), name, metav1.GetOptions{})
+}
+
+// DeletePod deletes a pod from the test namespace
+func (f *Framework) DeletePod(name string) error {
+	return f.K8sClient.CoreV1().Pods(f.NamespaceName).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+// GetVMI gets a VirtualMachineInstance
+func (f *Framework) GetVMI(namespace, name string) (*virtv1.VirtualMachineInstance, error) {
+	return f.KubevirtClient.VirtualMachineInstance(namespace).Get(context.Background(), name, &metav1.GetOptions{})
+}
+
+// ListVMIs lists VirtualMachineInstances in a namespace
+func (f *Framework) ListVMIs(namespace string) (*virtv1.VirtualMachineInstanceList, error) {
+	return f.KubevirtClient.VirtualMachineInstance(namespace).List(context.Background(), &metav1.ListOptions{})
+}
+
+// GetNode gets a node by name
+func (f *Framework) GetNode(name string) (*v1.Node, error) {
+	return f.K8sClient.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+}
+
+// WaitForPodPhase waits for a pod to reach a specific phase
+func (f *Framework) WaitForPodPhase(podName string, phase v1.PodPhase, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pod, err := f.GetPod(podName)
+		if err != nil {
+			return err
+		}
+		if pod.Status.Phase == phase {
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for pod %s to reach phase %s", podName, phase)
+}
+
+// WaitForVMI waits for a VMI to exist
+func (f *Framework) WaitForVMI(namespace, name string, timeout time.Duration) (*virtv1.VirtualMachineInstance, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		vmi, err := f.GetVMI(namespace, name)
+		if err == nil {
+			return vmi, nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return nil, fmt.Errorf("timeout waiting for VMI %s/%s to exist", namespace, name)
+}
+
+// WaitForVMIPhase waits for a VMI to reach a specific phase
+func (f *Framework) WaitForVMIPhase(namespace, name string, phase virtv1.VirtualMachineInstancePhase, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		vmi, err := f.GetVMI(namespace, name)
+		if err == nil && vmi.Status.Phase == phase {
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for VMI %s/%s to reach phase %s", namespace, name, phase)
+}
+
+// WaitForNodeReady waits for a node to be ready
+func (f *Framework) WaitForNodeReady(name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		node, err := f.GetNode(name)
+		if err == nil {
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+					return nil
+				}
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for node %s to be ready", name)
+}
+
+// WaitForPodDeleted waits for a pod to be deleted
+func (f *Framework) WaitForPodDeleted(podName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, err := f.GetPod(podName)
+		if err != nil {
+			// Pod not found, it's deleted
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for pod %s to be deleted", podName)
+}
+
+// WaitForVMIDeleted waits for a VMI to be deleted
+func (f *Framework) WaitForVMIDeleted(namespace, name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, err := f.GetVMI(namespace, name)
+		if err != nil {
+			// VMI not found, it's deleted
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for VMI %s/%s to be deleted", namespace, name)
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"maroonedpods.io/maroonedpods/tests/flags"
+	"maroonedpods.io/maroonedpods/tests/framework"
+)
+
+func TestTests(t *testing.T) {
+	flags.NormalizeFlags()
+	flag.Parse()
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MaroonedPods E2E Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	framework.InitFramework()
+})
+
+var _ = AfterSuite(func() {
+	// Cleanup if needed
+})

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+const (
+	// DefaultTimeout for operations
+	DefaultTimeout = 5 * time.Minute
+	// ShortTimeout for quick operations
+	ShortTimeout = 30 * time.Second
+	// LongTimeout for slow operations
+	LongTimeout = 10 * time.Minute
+)
+
+// GenerateTestName generates a unique name for test resources
+func GenerateTestName(prefix string) string {
+	rand.Seed(time.Now().UnixNano())
+	return fmt.Sprintf("%s-%d", prefix, rand.Int31())
+}
+
+// GenerateNamespaceName generates a unique namespace name for tests
+func GenerateNamespaceName(prefix string) string {
+	return GenerateTestName(prefix)
+}


### PR DESCRIPTION
Create comprehensive test suite following KubeVirt AAQ pattern:

Tests Structure:
- tests/tests_suite_test.go: Main Ginkgo suite setup
- tests/framework/: Test framework with K8s/KubeVirt client wrappers
- tests/builders/: Helper constructors for test objects (pods, etc.)
- tests/utils/: Common utilities (timeouts, name generation)
- tests/flags/: Test configuration flags

E2E Test Suites:
- e2e_pod_isolation_test.go: Pod isolation and VMI creation tests
  * VMI creation for marooned pods
  * Multiple pods in same namespace
  * No VMI for regular pods
  * Finalizer addition
- e2e_cleanup_test.go: Pod and VMI cleanup tests
  * VMI deletion when pod deleted
  * Graceful deletion handling
  * Force deletion handling
- e2e_dynamic_sizing_test.go: Dynamic VM sizing tests
  * Size VMI based on pod requests
  * Minimum base resources
  * Pods without requests
- e2e_warm_pool_test.go: Warm pool functionality tests
  * Pool VMI claiming
  * Pool state tracking
  * Pool VMI naming

Additional Changes:
- Add MaroonedPodLabel constant to pkg/util/util.go

Build with: cd tests && go build -mod=mod ./...
Run with: make functest